### PR TITLE
fix: add missing build to deploy workflow

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/setup-node@v4
       - name: Install dependencies
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Deploy
         id: deploy
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
The PR deploy job did not build the project before trying to deploy.