### PR TITLE
fix: grant PR write perms to deploy job

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -45,6 +45,8 @@ jobs:
     needs:
       - lint
       - build
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
The deploy job updates the preview message with the preview link for which it needs `pull-requests: write` access.