### PR TITLE
fix: incorrect naming of CF branch

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -9,8 +9,8 @@ on:
 
 env:
   CLOUDFLARE_PROJECT_NAME: landingpage
-  CLOUDFLARE_BRANCH_NAME: ${{ github.ref_name }}
-    
+  CLOUDFLARE_BRANCH_NAME: '#${{ github.event.pull_request.number }}:${{ github.event.pull_request.title }}'
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Previously the PR deploy workflow used the wrong source for naming the CF branch.