### PR TITLE
ci: improve cloudflare branch naming

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CLOUDFLARE_PROJECT_NAME: landingpage
-  CLOUDFLARE_BRANCH_NAME: '#${{ github.event.pull_request.number }}:${{ github.event.pull_request.title }}'
+  CLOUDFLARE_BRANCH_NAME: '#${{ github.event.pull_request.number }} / ${{ github.event.pull_request.title }}'
 
 jobs:
   lint:
@@ -73,4 +73,4 @@ jobs:
             **PR Preview**
             |                Name                 |                  Preview                 |
             | ----------------------------------- | ---------------------------------------- |
-            | `${{ env.CLOUDFLARE_BRANCH_NAME }}` | [Visit Preview](${{ env.PREVIEW_LINK }}) |
+            | ${{ env.CLOUDFLARE_BRANCH_NAME }} | [Visit Preview](${{ env.PREVIEW_LINK }}) |


### PR DESCRIPTION
The previous naming scheme was hard to read. This naming scheme separates the PR number and the title with a slash surrounded by spaces.