### PR TITLE
ci: specify major wrangler version

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run build
       - name: Deploy
         id: deploy
-        uses: cloudflare/wrangler-action
+        uses: cloudflare/wrangler-action@v3
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
actions throws a fit when there's no version specified so we go for wrangler-action@v3