### PR TITLE
ci: update PR target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
for testing purposes the event type for PR workflows was changed to `pull_request`. This is now changed back to `pull_request_target`.