### PR TITLE
fix: github redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,5 @@
 # Redirect to apex domain is done as bulk redirect on Cloudflare dashboard
 
 # Convenience redirects
-/github https://github.com/examplewastaken/ 301
-/gh https://github.com/examplewastaken 301
+/github/* https://github.com/examplewastaken/:splat 301
+/gh/* https://github.com/examplewastaken/:splat 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,7 @@
 # Redirect to apex domain is done as bulk redirect on Cloudflare dashboard
 
 # Convenience redirects
+/github https://github.com/examplewastaken/ 301
+/gh https://github.com/examplewastaken/ 301
 /github/* https://github.com/examplewastaken/:splat 301
 /gh/* https://github.com/examplewastaken/:splat 301


### PR DESCRIPTION
Currently, redirects to GitHub always default to the profile. This PR adds the functionality to preserve the path.